### PR TITLE
fix!: Update for 0.6+ compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module nonce-reset
 
 go 1.15
 
-require github.com/ethersphere/bee v0.5.3
+require github.com/ethersphere/bee v0.6.0


### PR DESCRIPTION
Simple change to allow building nonce-reset for use with 0.6+ versions of bee's statestore schema.